### PR TITLE
Update dependencies and remove some possible panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["multimedia::images"]
 keywords = ["openstreetmap", "osm", "map"]
 
 [dependencies]
-attohttpc = { version = "0.17", default-features = false, features = ["tls-rustls"] }
-png = { version = "0.16", default-features = false }
+attohttpc = { version = "0.19", default-features = false, features = ["tls-rustls"] }
+png = { version = "0.17", default-features = false }
 rayon = "1.5"
-tiny-skia = "0.5"
+tiny-skia = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,9 @@ fn simplify(points: Vec<(f64, f64)>, tolerance: f64) -> Vec<(f64, f64)> {
         }
     }
 
-    simplified_points.push(*points.last().unwrap());
+    let last_point = points
+        .last()
+        .expect("Internal logic error - 'points' must have at least two points");
+    simplified_points.push(*last_point);
     simplified_points
 }

--- a/src/tools/circle.rs
+++ b/src/tools/circle.rs
@@ -125,14 +125,15 @@ impl Tool for Circle {
         path_builder.push_circle(x as f32, y as f32, self.radius);
 
         path_builder.close();
-        let path = path_builder.finish().unwrap();
 
-        pixmap.fill_path(
-            &path,
-            &self.color.0,
-            FillRule::default(),
-            Transform::default(),
-            None,
-        );
+        if let Some(path) = path_builder.finish() {
+            pixmap.fill_path(
+                &path,
+                &self.color.0,
+                FillRule::default(),
+                Transform::default(),
+                None,
+            );
+        }
     }
 }

--- a/src/tools/icon.rs
+++ b/src/tools/icon.rs
@@ -13,7 +13,7 @@ use tiny_skia::{Pixmap, PixmapMut, PixmapPaint, Transform};
 ///     .lon_coordinate(50.5)
 ///     .x_offset(3.4)
 ///     .y_offset(10.)
-///     .path("icon.png")
+///     .path("examples/icons/icon-flag.png")
 ///     .unwrap()
 ///     .build()
 ///     .unwrap();

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -176,18 +176,18 @@ impl Tool for Line {
             }
         }
 
-        let path = path_builder.finish().unwrap();
-
-        pixmap.stroke_path(
-            &path,
-            &self.color.0,
-            &Stroke {
-                width: self.width,
-                line_cap: LineCap::Round,
-                ..Default::default()
-            },
-            Transform::default(),
-            None,
-        );
+        if let Some(path) = path_builder.finish() {
+            pixmap.stroke_path(
+                &path,
+                &self.color.0,
+                &Stroke {
+                    width: self.width,
+                    line_cap: LineCap::Round,
+                    ..Default::default()
+                },
+                Transform::default(),
+                None,
+            );
+        }
     }
 }


### PR DESCRIPTION
Thanks for this library! I was using it and with some random test coordinates (which were possibly outside of valid range) caused the circle tool to panic

The panic happened as tiny_skia's PathBuilder "returns None when Path is empty or has invalid bounds". Not drawing an empty path seemed fine; not drawing an invalid line might not be ideal but seemed pretty esoteric

Also updated to latest version of tiny-skia etc (doesn't seem to be any relevant breaking changes to these)