### PR TITLE
fix: use height instead of width for the y-coordinate calculation

### DIFF
--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -43,7 +43,7 @@ impl Bounds {
 
     /// Helper function for converting a y coordinate to pixel.
     pub fn y_to_px(&self, y: f64) -> f64 {
-        let px = (y - self.y_center) * f64::from(self.tile_size) + f64::from(self.width) / 2.;
+        let px = (y - self.y_center) * f64::from(self.tile_size) + f64::from(self.height) / 2.;
         px.round()
     }
 }


### PR DESCRIPTION
Hello,

The current implementation appears to be incorrectly using `width` and `height`. When generating an image with different `width` and `height` values, it results in drawing the map outside the image boundaries. This pull request fixes the typo and resolves the issue.