### PR TITLE
proposal: enhancing staticmap generation with custom tile fetching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,13 @@ categories = ["multimedia::images"]
 keywords = ["openstreetmap", "osm", "map"]
 
 [dependencies]
-attohttpc = { version = "0.27", default-features = false, features = ["tls-rustls"] }
+attohttpc = { version = "0.27", default-features = false, features = [
+    "tls-rustls",
+], optional = true }
 png = { version = "0.17", default-features = false }
-rayon = "1.5"
+rayon = { version = "1.5", optional = true }
 tiny-skia = "0.11"
+
+[features]
+default = ["default-tile-fetcher"]
+default-tile-fetcher = ["attohttpc", "rayon"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     /// Request error when fetching tile from a tile server.
     TileError {
         /// Internal error from the HTTP client.
-        error: Box<dyn std::error::Error + Send>,
+        error: Box<dyn std::error::Error>,
         /// The URL which failed.
         url: String,
     },

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     /// Request error when fetching tile from a tile server.
     TileError {
         /// Internal error from the HTTP client.
-        error: attohttpc::Error,
+        error: Box<dyn std::error::Error + Send>,
         /// The URL which failed.
         url: String,
     },
@@ -39,7 +39,7 @@ impl std::error::Error for Error {
         match *self {
             Error::PngEncodingError(ref error) => Some(error),
             Error::PngDecodingError(ref error) => Some(error),
-            Error::TileError { ref error, .. } => Some(error),
+            Error::TileError { ref error, .. } => Some(error.as_ref()),
             _ => None,
         }
     }

--- a/src/fetchers/default.rs
+++ b/src/fetchers/default.rs
@@ -3,6 +3,18 @@ use rayon::prelude::*;
 
 use crate::{fetchers::TileFetcher, Error};
 
+/// `DefaultTileFetcher` is the default implementation of the `TileFetcher` trait,
+/// designed to fetch raster tiles from Open Street Map (OSM) providers concurrently.
+/// It leverages `attohttpc` for making HTTP GET requests and `rayon` for parallelizing
+/// the fetch operations across multiple URLs.
+///
+/// If the request is successful, it returns the raw bytes of the tile image.
+/// In case of failure, it wraps the error along with the offending URL in a
+/// `TileError` and returns it, allowing for easy identification of problematic requests.
+///
+/// This implementation is suitable for most use cases requiring tile fetching from
+/// OSM or similar tile providers. It optimizes for speed and error handling, making
+/// it a robust choice for applications needing reliable tile retrieval.
 pub struct DefaultTileFetcher;
 
 impl TileFetcher for DefaultTileFetcher {

--- a/src/fetchers/default.rs
+++ b/src/fetchers/default.rs
@@ -1,0 +1,23 @@
+use attohttpc::{Method, RequestBuilder, Response};
+use rayon::prelude::*;
+
+use crate::{fetchers::TileFetcher, Error};
+
+pub struct DefaultTileFetcher;
+
+impl TileFetcher for DefaultTileFetcher {
+    fn fetch(&self, tile_urls: &[&str]) -> Vec<std::result::Result<Vec<u8>, crate::error::Error>> {
+        tile_urls
+            .par_iter()
+            .map(|tile_url| {
+                RequestBuilder::try_new(Method::GET, &tile_url)
+                    .and_then(RequestBuilder::send)
+                    .and_then(Response::bytes)
+                    .map_err(|error| Error::TileError {
+                        error: Box::new(error),
+                        url: tile_url.to_string(),
+                    })
+            })
+            .collect()
+    }
+}

--- a/src/fetchers/mod.rs
+++ b/src/fetchers/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "default-tile-fetcher")]
+mod default;
+mod noop;
+
+#[cfg(feature = "default-tile-fetcher")]
+pub use default::DefaultTileFetcher;
+pub use noop::NoopTileFetcher;
+
+pub trait TileFetcher {
+    fn fetch(&self, tile_urls: &[&str]) -> Vec<std::result::Result<Vec<u8>, crate::error::Error>>;
+}

--- a/src/fetchers/mod.rs
+++ b/src/fetchers/mod.rs
@@ -6,6 +6,30 @@ mod noop;
 pub use default::DefaultTileFetcher;
 pub use noop::NoopTileFetcher;
 
+/// `TileFetcher` is a trait for fetching Open Street Map raster tiles.
+/// It provides a method, `fetch`, for retrieving tiles from specified URLs, returning
+/// a vector of results containing either the tile data as bytes or an error.
+///
+/// You can implement their own `TileFetcher` for specific needs, such as adding
+/// caching or API request throttling to manage server load effectively.
+///
+/// # Implementations
+/// - `DefaultTileFetcher`: Utilizes `attohttpc` for HTTP requests and `rayon` for
+///   parallel fetching. Enabled with default features, it offers efficient and concurrent
+///   tile retrieval.
+/// - `NoopTileFetcher`: Active when default features are disabled, performs no actual
+///   HTTP requests. Instead, it returns a single-pixel PNG image, avoiding dependencies
+///   on `attohttpc` and `rayon`.
 pub trait TileFetcher {
+    /// Fetches raster tiles from specified URLs.
+    ///
+    /// # Parameters
+    /// - `tile_urls`: A slice of string slices, each representing a URL from which to fetch a tile.
+    ///
+    /// # Returns
+    /// A `Vec<Result<Vec<u8>, crate::error::Error>>`, with each element corresponding to a tile fetch attempt.
+    /// On success, an element is `Ok(Vec<u8>)` with the tile's bytes. On failure, it is recommended to
+    /// wrap the error in `crate::error::Error::TileError` variant, resulting in `Err(crate::error::Error)`
+    /// that provides details of the encountered issue and the URL of the failed request.
     fn fetch(&self, tile_urls: &[&str]) -> Vec<std::result::Result<Vec<u8>, crate::error::Error>>;
 }

--- a/src/fetchers/noop.rs
+++ b/src/fetchers/noop.rs
@@ -1,5 +1,8 @@
 use crate::fetchers::TileFetcher;
 
+/// `NoopTileFetcher` is a no-operation (noop) implementation of the `TileFetcher` trait,
+/// designed as a default placeholder within the `StaticMapBuilder`. This implementation
+/// avoids performing any network requests or actual tile retrieval operations.
 pub struct NoopTileFetcher;
 
 impl TileFetcher for NoopTileFetcher {

--- a/src/fetchers/noop.rs
+++ b/src/fetchers/noop.rs
@@ -1,0 +1,15 @@
+use crate::fetchers::TileFetcher;
+
+pub struct NoopTileFetcher;
+
+impl TileFetcher for NoopTileFetcher {
+    fn fetch(&self, tile_urls: &[&str]) -> Vec<std::result::Result<Vec<u8>, crate::error::Error>> {
+        let one_pixel = &[
+            137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1,
+            8, 4, 0, 0, 0, 181, 28, 12, 2, 0, 0, 0, 11, 73, 68, 65, 84, 120, 218, 99, 100, 96, 0,
+            0, 0, 6, 0, 2, 48, 129, 208, 47, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ];
+        println!("{:?}", one_pixel);
+        tile_urls.iter().map(|_| Ok(one_pixel.to_vec())).collect()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ mod map;
 /// Tools for drawing features onto the map.
 pub mod tools;
 
+/// Tile Fetching Strategies for Static Map Generation.
 pub mod fetchers;
 
 pub use bounds::Bounds;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ mod map;
 /// Tools for drawing features onto the map.
 pub mod tools;
 
+pub mod fetchers;
+
 pub use bounds::Bounds;
 pub use error::Error;
 pub use map::{StaticMap, StaticMapBuilder};

--- a/src/map.rs
+++ b/src/map.rs
@@ -124,6 +124,7 @@ impl StaticMapBuilder {
         self
     }
 
+    /// Sets a custom `TileFetcher`.
     pub fn tile_fetcher(mut self, tile_fetcher: impl TileFetcher + 'static) -> Self {
         self.tile_fetcher = Box::new(tile_fetcher);
         self


### PR DESCRIPTION
Hello,

Hope you're doing well! I've been using your project and found it incredibly useful for my needs. As I often generate static maps and frequently adjust parameters, I've been considering ways to enhance the tile fetching process for efficiency.

I'm utilizing `tokio` and `reqwest` for async operations and aiming to use `http_cache_reqwest` for local caching of map tiles. This approach should minimize redundant fetches, speed up development, and reduce unnecessary requests. Additionally, I'm exploring throttling options to manage API request rates better.

This PR includes:

- A new `TileFetcher` trait for customizable tile fetching, adding flexibility.
- Preserving the original implementation in `DefaultTileFetcher`, utilizing `attohttpc` and `rayon`, to maintain a robust default option. My intention is not to replace but to expand the available choices.

Here's how I'm implementing my custom `TileFetcher`:

<details>

```rust
pub struct TokioFetcher {
    client: ClientWithMiddleware,
    runtime: Arc<Runtime>,
}

impl TokioFetcher {
    pub fn new() -> Self {
        let client = ClientBuilder::new(Client::new())
            .with(Cache(HttpCache {
                mode: CacheMode::Default,
                manager: CACacheManager::default(),
                options: HttpCacheOptions::default(),
            }))
            .build();
        let runtime = Arc::new(Runtime::new().unwrap());
        TokioFetcher { client, runtime }
    }
}

impl TileFetcher for TokioFetcher {
    fn fetch(&self, urls: &[&str]) -> Vec<Result<Vec<u8>, Error>> {
        self.runtime.block_on(async {
            let handles = urls
                .into_iter()
                .map(|&url| {
                    let client = self.client.clone();
                    let url = url.to_owned();
                    tokio::spawn(async move {
                        let body = client
                            .get(&url)
                            .header(header::USER_AGENT, "MyCustomUserAgent/1.0")
                            .send()
                            .await
                            .map_err(to_boxed_error)?
                            .bytes()
                            .await
                            .map_err(to_boxed_error)?
                            .to_vec();
                        Ok(body)
                    })
                })
                .collect::<Vec<_>>();

            futures::future::join_all(handles)
                .await
                .into_iter()
                .map(|r| match r {
                    Ok(result) => result,
                    Err(e) => Err(to_boxed_error(e)),
                })
                .zip(urls)
                .map(|(res, url)| {
                    res.map_err(|e| Error::TileError {
                        error: e,
                        url: url.to_string(),
                    })
                })
                .collect::<Vec<_>>()
        })
    }
}
```

</details>

I've crafted this PR to introduce these features, thinking they might benefit others facing similar challenges. Eager to hear your feedback or suggestions for any improvements.
