### PR TITLE
fix: ensure shapes remain within image when center coordinates are specified

### DIFF
--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -165,10 +165,23 @@ impl BoundsBuilder {
             .map(|x| x.extent(zoom, self.tile_size.into()))
             .collect();
 
-        self.lon_min = extent.iter().map(|x| x.0).fold(f64::NAN, f64::min);
-        self.lat_min = extent.iter().map(|x| x.1).fold(f64::NAN, f64::min);
-        self.lon_max = extent.iter().map(|x| x.2).fold(f64::NAN, f64::max);
-        self.lat_max = extent.iter().map(|x| x.3).fold(f64::NAN, f64::max);
+        let lon_min = extent.iter().map(|x| x.0).fold(f64::NAN, f64::min);
+        let lat_min = extent.iter().map(|x| x.1).fold(f64::NAN, f64::min);
+        let lon_max = extent.iter().map(|x| x.2).fold(f64::NAN, f64::max);
+        let lat_max = extent.iter().map(|x| x.3).fold(f64::NAN, f64::max);
+
+        if let (Some(lon), Some(lat)) = (self.lon_center, self.lat_center) {
+            // Adjust bounds to center on (lon_center, lat_center), expanding as needed
+            self.lon_min = lon_min.min(2. * lon - lon_max);
+            self.lat_min = lat_min.min(2. * lat - lat_max);
+            self.lon_max = lon_max.max(2. * lon - lon_min);
+            self.lat_max = lat_max.max(2. * lat - lat_min);
+        } else {
+            self.lon_min = lon_min;
+            self.lat_min = lat_min;
+            self.lon_max = lon_max;
+            self.lat_max = lat_max;
+        }
     }
 
     fn calculate_zoom(&mut self, tools: &[Box<dyn Tool>]) -> u8 {


### PR DESCRIPTION
Hello,

I've refined the `staticmap` library's `determine_extent` method. Previously, it did not account for the center when calculating extents, often causing shapes to fall outside the map view, as shown in the following picture.

```rs
use staticmap::{
    tools::{CircleBuilder, Color},
    Error, StaticMapBuilder,
};

fn main() -> Result<(), Error> {
    let mut map = StaticMapBuilder::new()
        .width(200)
        .height(200)
        .lat_center(51.477026681134724)
        .lon_center(0.)
        .url_template("https://a.tile.osm.org/{z}/{x}/{y}.png")
        .build()?;

    let circle1 = CircleBuilder::new()
        .lat_coordinate(48.858504158739485)
        .lon_coordinate(2.2945027640811704)
        .color(Color::new(true, 255, 0, 0, 255))
        .radius(5.)
        .build()?;

    let circle2 = CircleBuilder::new()
        .lat_coordinate(52.50728687282466)
        .lon_coordinate(13.439761448109806)
        .color(Color::new(true, 0, 0, 255, 255))
        .radius(5.)
        .build()?;

    map.add_tool(circle1);
    map.add_tool(circle2);

    map.save_png("determine_extent_with_center.png")?;

    Ok(())
}
```

![determine_extent_with_center_before](https://github.com/danielalvsaaker/staticmap/assets/45287/a8766e3d-1ef7-49b5-a514-e562e2fb0b8e)

With the fix, as shown in the next figure, shapes are correctly positioned within the map boundaries, ensuring the specified center is truly central.

![determine_extent_with_center](https://github.com/danielalvsaaker/staticmap/assets/45287/d523582f-8e1b-4975-80d3-3edeaeaa62f8)

Please find the pull request for your review and feedback.
