### PR TITLE
Fix center

### DIFF
--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,4 +1,4 @@
-use crate::{lat_to_y, lon_to_x, tools::Tool};
+use crate::{lat_to_y, lon_to_x, tools::Tool, y_to_lat};
 
 /// Helper struct for converting to pixels,
 /// and to pass information about map bounds to implementors of [Tool][Tool].
@@ -114,10 +114,14 @@ impl BoundsBuilder {
 
         let (lon_center, lat_center) = match self.lon_center.zip(self.lat_center) {
             Some((x, y)) => (x, y),
-            _ => (
-                (self.lon_min + self.lon_max) / 2.,
-                (self.lat_min + self.lat_max) / 2.,
-            ),
+            _ => {
+                let y_min = lat_to_y(self.lat_max, zoom);
+                let y_max = lat_to_y(self.lat_min, zoom);
+                (
+                    (self.lon_min + self.lon_max) / 2.,
+                    y_to_lat((y_min + y_max) / 2., zoom),
+                )
+            }
         };
 
         let x_center = lon_to_x(lon_center, zoom);

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,4 +1,4 @@
-use crate::{lat_to_y, lon_to_x, tools::Tool, y_to_lat};
+use crate::{lat_to_y, lon_to_x, tools::Tool};
 
 /// Helper struct for converting to pixels,
 /// and to pass information about map bounds to implementors of [Tool][Tool].
@@ -112,20 +112,16 @@ impl BoundsBuilder {
             self.calculate_zoom(tools)
         };
 
-        let (lon_center, lat_center) = match self.lon_center.zip(self.lat_center) {
-            Some((x, y)) => (x, y),
+        let (x_center, y_center) = match self.lon_center.zip(self.lat_center) {
+            Some((lon, lat)) => (lon_to_x(lon, zoom), lat_to_y(lat, zoom)),
             _ => {
+                let x_min = lon_to_x(self.lon_min, zoom);
+                let x_max = lon_to_x(self.lon_max, zoom);
                 let y_min = lat_to_y(self.lat_max, zoom);
                 let y_max = lat_to_y(self.lat_min, zoom);
-                (
-                    (self.lon_min + self.lon_max) / 2.,
-                    y_to_lat((y_min + y_max) / 2., zoom),
-                )
+                ((x_min + x_max) / 2., (y_min + y_max) / 2.)
             }
         };
-
-        let x_center = lon_to_x(lon_center, zoom);
-        let y_center = lat_to_y(lat_center, zoom);
 
         let x_m = 0.5 * f64::from(self.width) / f64::from(self.tile_size);
         let y_m = 0.5 * f64::from(self.height) / f64::from(self.tile_size);


### PR DESCRIPTION
Hello,

I've discovered a centering issue in the `staticmap` crate related to the Mercator projection's y-axis conversion. When a center latitude/longitude is not specified, the existing method calculates the center using raw latitude and longitude values. This is accurate for the x-axis, as it's linear, but not for the y-axis due to its non-linear scaling.

Here's an example of the issue, where the rectangle is not contained within the map bounds due to incorrect center calculation:

```rs
use staticmap::{
    tools::{Color, LineBuilder},
    Error, StaticMapBuilder,
};

fn main() -> Result<(), Error> {
    let mut map = StaticMapBuilder::new()
        .width(300)
        .height(300)
        .zoom(5)
        .build()
        .unwrap();

    let lat: &[f64] = &[80., 80., 82.04, 82.04, 80.];
    let lon: &[f64] = &[91., 104., 104., 91., 91.];

    let red = Color::new(true, 255, 0, 0, 255);

    let line = LineBuilder::new()
        .lat_coordinates(lat.iter().copied())
        .lon_coordinates(lon.iter().copied())
        .width(3.)
        .color(red)
        .build()?;

    map.add_tool(line);

    map.save_png("fix-center.png")?;

    Ok(())
}
```

![fix-center-before](https://github.com/danielalvsaaker/staticmap/assets/45287/945bb56a-c5fc-43c7-9238-e90bf0b67913)

To address this, the upcoming pull request modifies the centering logic to calculate the center using x-y coordinates after applying the Mercator projection. This results in the accurate depiction of the center, ensuring that shapes like rectangles are properly aligned and contained within the map view:

![fix-center](https://github.com/danielalvsaaker/staticmap/assets/45287/f6899ca8-c6fd-4402-81ef-008d26a06364)

This fix is critical for the precise representation of geospatial data and enhances the reliability of map visualizations centered around a specific point.
